### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * 1' # Weekly on Mondays
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nikomatt69/keykeeper/security/code-scanning/2](https://github.com/nikomatt69/keykeeper/security/code-scanning/2)

To address the issue, add a `permissions` block at the root level of the workflow. This block will define the least privileges required for the workflow to operate. Based on the tasks in the workflow, the appropriate permissions are:
- `contents: read` — Required for reading repository contents.
- `security-events: write` — Required for uploading security scan results (e.g., SARIF files).

This change ensures the GITHUB_TOKEN is limited to the necessary permissions for the workflow's operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
